### PR TITLE
Fix invalid LaTeX strings

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -77,17 +77,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/dist_fit.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/probfit.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/dist_fit.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/probfit.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/dist_fit"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/dist_fit"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/probfit"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/probfit"
 	@echo "# devhelp"
 
 epub:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# dist_fit documentation build configuration file, created by
+# probfit documentation build configuration file, created by
 # sphinx-quickstart on Sat Nov 10 11:16:37 2012.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -216,7 +216,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'probfit.tex', u'dist\\_fit Documentation',
+  ('index', 'probfit.tex', u'probfit Documentation',
    u'Piti Ongmongkolkul', 'manual'),
 ]
 

--- a/probfit/costfunc.pyx
+++ b/probfit/costfunc.pyx
@@ -161,7 +161,7 @@ cdef class UnbinnedLH:
               likelihood
 
               .. math::
-                \\textrm{ext_term} = \\int_{x \in \\textrm{extended_bound}}f(x, args, \\ldots) \\textrm{d} x
+                \\textrm{ext term} = \\int_{x \in \\textrm{extended bound}}f(x, \\textrm{args}, \\ldots) \\textrm{d} x
 
             - **extended_bound** Bound for calculating extended term.
               Default None(minimum and maximum of data will be used).
@@ -385,7 +385,7 @@ cdef class BinnedLH:
                     ROOFIT used **f** evaluated at midpoint.
 
             - :math:`s_i` is a scaled factor. It's 1 if ``sum_w2=False``.
-              It's :math:`s_i = \\frac{h_i}{\sum_{j \in \\textrm{bin_i}} w_j^2}`
+              It's :math:`s_i = \\frac{h_i}{\sum_{j \in \\textrm{bin }i} w_j^2}`
               if ``sum_w2=True``. The factor will scale the statistics to the
               unweighted data.
 


### PR DESCRIPTION
The problem reported in #67 was due to the argument of `textrm` having an underscore, which isn't valid.

I also changed the instances I could find of 'dist_prob' to 'probfit', when I noticed that the PDF was generated with dist_fit as the title 😄 